### PR TITLE
Create help.js | Add status command with uptime and latencies

### DIFF
--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,27 @@
+const { EmbedBuilder } = require('discord.js');
+const { formatUptime } = require('../utils/uptime');
+const COLORS = require('../utils/colors');
+
+module.exports = {
+  name: 'status',
+  aliases: ['ping', 'estado'],
+  description: 'Muestra el estado actual del bot',
+  async execute(message, args, client) {
+    const botLatency = Date.now() - message.createdTimestamp;
+    const wsLatency = Math.round(client.ws.ping);
+
+    const embed = new EmbedBuilder()
+      .setTitle('📊 Estado del Bot')
+      .setDescription(`Solicitado por ${message.author}`)
+      .addFields(
+        { name: '🏷 Bot Latency', value: `\`${botLatency} ms\``, inline: true },
+        { name: '🌐 WS Latency', value: `\`${wsLatency} ms\``, inline: true },
+        { name: '⏱ Uptime', value: formatUptime(Math.floor(process.uptime())), inline: true },
+        { name: '📁 Memoria (RSS)', value: `\`${Math.round(process.memoryUsage().rss / 1024 / 1024)} MB\``, inline: true },
+      )
+      .setColor(COLORS.status)
+      .setTimestamp();
+
+    return message.reply({ embeds: [embed] });
+  }
+};


### PR DESCRIPTION
- Created the main $status command with aliases $ping and $estado
- Includes bot latency, WS latency, uptime, and memory usage
- Implemented embedding with a consistent design and centralized colors