### PR TITLE
Create messageCreate.js | Handle prefixed commands and permissions

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -1,0 +1,29 @@
+const { noPermissionEmbed, hasPermission } = require('../utils/permissions');
+const PREFIX = (process.env.BOT_PREFIX || '$').trim();
+const GUILD_ID = process.env.GUILD_ID;
+
+module.exports = {
+  name: 'messageCreate',
+  async execute(message, client) {
+    if (message.author.bot) return;
+    if (!message.guild || message.guild.id !== GUILD_ID) return;
+    if (!message.content.startsWith(PREFIX)) return;
+
+    const args = message.content.slice(PREFIX.length).trim().split(/\s+/);
+    const commandName = args.shift().toLowerCase();
+    const command = client.commands.get(commandName);
+
+    if (!command) return;
+
+    if (!hasPermission(message)) {
+      return message.reply({ embeds: [noPermissionEmbed(message.author)] });
+    }
+
+    try {
+      await command.execute(message, args, client);
+    } catch (error) {
+      console.error(error);
+      message.reply('❌ Ocurrió un error al ejecutar el comando.');
+    }
+  },
+};


### PR DESCRIPTION
- Processes messages with a configured prefix (default $)
- Restricts commands to the GUILD_ID server
- Validates permissions by combining the ADMIN role and the DEV_ID user
- Handles errors when executing commands